### PR TITLE
docker fixes

### DIFF
--- a/docker/README.rst
+++ b/docker/README.rst
@@ -20,7 +20,7 @@ The quickest way to try out the kit is to run::
 
     # Open a new terminal to start the driver for a 2 minute (120 seconds) test
     # and save the results in /tmp/results.  Note /tmp not needed.
-    docker/run-rest results 120
+    docker/run-test results 120
 
     # In the previous terminal where we ran "docker run", process results.
     dbt5-post-process /tmp/results/ce_mix.log

--- a/docker/build-database
+++ b/docker/build-database
@@ -46,7 +46,7 @@ docker build -t dbt5-database-${DBMS}-${SCALE}s \
 		--build-arg PGVERSION=$PGVERSION \
 		--build-arg DBMS=$DBMS \
 		--build-arg SCALE=$SCALE \
-		--shm-size=256m \
+		--shm-size=1g \
 		-f Dockerfile.database $TOPDIR
 if [ $? -ne 0 ]; then
 	echo "usage: $0 [SCALE [DBMS [DBMSVER]]]"


### PR DESCRIPTION
This is a simple docker readme fix for people copying instructions out of the guide, and also fixes an issue I ran into during the data generator stage, where at the end it vacuums the dbt5 database and would run out of memory. 