### PR TITLE
fix(storedproc/c): wrong length subtracted

### DIFF
--- a/storedproc/pgsql/c/trade_lookup.c
+++ b/storedproc/pgsql/c/trade_lookup.c
@@ -2086,7 +2086,7 @@ TradeLookupFrame3(PG_FUNCTION_ARGS)
 
 			trade_list_str = SPI_getvalue(tuple, tupdesc, 7);
 			strncat(values[i_trade_list], trade_list_str, length_tl);
-			length_tl -= strlen(tmp);
+			length_tl -= strlen(trade_list_str);
 			if (length_tl < 0) {
 				FAIL_FRAME("trade_list values needs to be increased");
 			}


### PR DESCRIPTION
Gives the following outputs repeatedly when running simple tests
```
WARNING:  UNEXPECTED EXECUTION RESULT: trade_lookup.c 2091
trade_list values needs to be increased
WARNING:  UNEXPECTED EXECUTION RESULT: trade_lookup.c 2016
trade_list values needs to be increased
```