### PR TITLE
fix(storedfunc/c): consistent type for comm_amount

### DIFF
--- a/storedproc/pgsql/c/trade_result.c
+++ b/storedproc/pgsql/c/trade_result.c
@@ -364,7 +364,7 @@ static cached_statement TRF4_statements[] = {
 
 static cached_statement TRF5_statements[] = {
 
-	{ SQLTRF5_1, 5, { FLOAT4OID, TIMESTAMPOID, TEXTOID, FLOAT8OID, INT8OID } },
+	{ SQLTRF5_1, 5, { FLOAT8OID, TIMESTAMPOID, TEXTOID, FLOAT8OID, INT8OID } },
 
 	{ SQLTRF5_2, 3, { INT8OID, TIMESTAMPOID, TEXTOID } },
 


### PR DESCRIPTION
Fixes #15.

As of commit 5575431ad9826c532a466191239338c635002b0f, there is only this single occurrence of FLOAT4OID and all others uses FLOAT8OID, and comm_amount is defined as double type in trade_result.c:1654 and converted using GetFloat8 in lines 1667 and 1668 of the same file. The following error is no longer raised after this fix:

```
ERROR:  numeric field overflow
DETAIL:  A field with precision 10, scale 2 must round to an absolute value less than 10^8. CONTEXT:  SQL statement "UPDATE trade
SET t_comm = $1
  , t_dts = $2
  , t_st_id = $3
  , t_trade_price = $4
WHERE t_id = $5"
```