### PR TITLE
fix(bh): exception string being freed during throw

### DIFF
--- a/src/BrokerageHouse/BrokerageHouse.cpp
+++ b/src/BrokerageHouse/BrokerageHouse.cpp
@@ -194,11 +194,11 @@ workerThread(void *data)
 					cout << "wrong txn type" << endl;
 					iRet = ERR_TYPE_WRONGTXN;
 				}
-			} catch (const char *str) {
+			} catch (std::string const &e) {
 				pid_t pid = syscall(SYS_gettid);
 				ostringstream msg;
 				msg << time(NULL) << " " << pid << " "
-					<< szTransactionName[pMessage->TxnType] << endl;
+					<< szTransactionName[pMessage->TxnType] << " " << e << endl;
 				pThrParam->pBrokerageHouse->logErrorMessage(msg.str());
 				iRet = CBaseTxnErr::EXPECTED_ROLLBACK;
 			}

--- a/src/transactions/pgsql/DBConnection.cpp
+++ b/src/transactions/pgsql/DBConnection.cpp
@@ -217,7 +217,7 @@ CDBConnection::exec(const char *sql, int nParams = 0,
 			<< "SQL: " << sql << endl
 			<< PQresultErrorMessage(res) << endl;
 		rollback();
-		throw msg.str().c_str();
+		throw msg.str();
 		break;
 	case PGRES_EMPTY_QUERY:
 	case PGRES_COPY_OUT:


### PR DESCRIPTION
The const char * thrown here is obtained from a std::string and is subject to being freed while the exception is being thrown.

It seems like all other exceptions thrown in the repo are of std::exception class, either from standard exception classes like std::runtime_error and std::range_error, or custom subclass C.*Error, that can be shown with
```
  grep -RHn 'throw ' src inc TestHarness/ \
  | grep -v 'C.*Err' | grep -v 'std::runtime_error'
```
Although given this fact, the exception thrown here is caught early at CBrokerageHouse::Run* methods, e.g. line 856 of BrokerageHouse.cpp simply logging a text saying TR EXCEPTION, and it might be making too much changes to apply for this simple improvement if consistency of exception class is demanded.
https://github.com/osdldbt/dbt5/blob/5575431ad9826c532a466191239338c635002b0f/src/BrokerageHouse/BrokerageHouse.cpp#L856