### PR TITLE
add .gitignore entries for build artifacts and EGenLoader output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ builds/
 
 # PostgreSQL
 storedproc/pgsql/c/*.sql
+storedproc/pgsql/c/*.bc
 
 # quilt
 .pc
@@ -28,3 +29,7 @@ doc/html
 doc/pdf
 
 egen/
+
+# EGenLoader / dbt5 build output and logs
+EGenLoader*.log
+egenloader.out


### PR DESCRIPTION
- Ignore `storedproc/pgsql/c/*.bc` (LLVM bitcode from building PostgreSQL C extensions).
- Ignore `EGenLoader*.log` and `egenloader.out` (output from EGenLoader when running `dbt5 build`).
- Prevents these generated files from being committed after a local build.