### PR TITLE
Add core dump support to Docker Compose services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,3 +12,4 @@ Dockerfile
 .git
 .gitignore
 install_manifest.txt
+cores/

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ egen/
 # EGenLoader / dbt5 build output and logs
 EGenLoader*.log
 egenloader*.out
+
+# Core dumps
+cores/

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,13 +1,34 @@
 ---
-# Debugging: services build with RelWithDebInfo so core dumps have symbols.
-# Core dumps are captured automatically by the host's systemd-coredump.
+# Debugging core dumps
 #
-# List crashes:   coredumpctl list
-# Show backtrace: coredumpctl info <PID>
-# Open in GDB:    coredumpctl gdb <PID>
+# On systemd hosts, crashes inside containers are captured automatically by
+# the host's systemd-coredump because kernel.core_pattern is a kernel-level
+# setting shared across all containers.
 #
-# Or debug inside the container (no host/guest lib mismatch):
-#   docker compose exec broker gdb /opt/egen/bin/BrokerageHouseMain <corefile>
+# Step 1 - list captured crashes on the host:
+#   coredumpctl list
+#
+# Step 2 - show signal, executable, and partial backtrace:
+#   coredumpctl info <PID>
+#
+# Step 3 - extract the core file:
+#   sudo coredumpctl dump <PID> -o /tmp/core.file
+#
+# Step 4 - debug inside the container where the binary and libs match the core.
+# Replace <service> and <binary> with the crashed service:
+#   broker  -> /opt/egen/bin/BrokerageHouseMain
+#   market  -> /opt/egen/bin/MarketExchangeMain
+#   driver  -> /opt/egen/bin/DriverMain
+#
+#   docker compose run --no-deps --rm \
+#     -v /tmp/core.file:/tmp/core.file \
+#     <service> \
+#     gdb /opt/egen/bin/<binary> /tmp/core.file
+#
+# Step 5 - inside GDB, print the backtrace:
+#   (gdb) bt                    # short backtrace
+#   (gdb) bt full               # backtrace with local variable values
+#   (gdb) thread apply all bt   # backtrace for all threads
 services:
   dbt5-base:
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,13 @@
 ---
-# Debugging: services build with RelWithDebInfo and write core dumps to ./cores/.
-# Host prerequisite (one-time):
-#   sudo sysctl -w kernel.core_pattern=core.%e.%p
-# Analyse a core inside the matching container (recommended):
-#   docker compose exec broker gdb /opt/egen/bin/BrokerageHouseMain /cores/core.*
-# Analyse a core locally (binaries and libs are auto-copied to ./cores/):
-#   gdb -ex "set sysroot ./cores/sysroot" ./cores/BrokerageHouseMain ./cores/core.*
+# Debugging: services build with RelWithDebInfo so core dumps have symbols.
+# Core dumps are captured automatically by the host's systemd-coredump.
+#
+# List crashes:   coredumpctl list
+# Show backtrace: coredumpctl info <PID>
+# Open in GDB:    coredumpctl gdb <PID>
+#
+# Or debug inside the container (no host/guest lib mismatch):
+#   docker compose exec broker gdb /opt/egen/bin/BrokerageHouseMain <corefile>
 services:
   dbt5-base:
     build:
@@ -14,7 +16,7 @@ services:
         ARG PGVER=18
         FROM postgres:$${PGVER}
         RUN apt-get update && apt-get install -y --no-install-recommends \
-            build-essential cmake gdb libc6-dbg \
+            build-essential cmake gdb \
             postgresql-server-dev-$${PG_MAJOR} unzip \
             && rm -rf /var/lib/apt/lists/*
         COPY *-tpc-e-tool.zip /tmp/
@@ -63,13 +65,11 @@ services:
       - "30000:30000"
     volumes:
       - .:/usr/local/src/dbt5:ro
-      - ./cores:/cores
     working_dir: /usr/local/src/dbt5
     command:
       - sh
       - -c
       - |
-        mkdir -p /cores && chmod 777 /cores
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build /tmp/build
@@ -77,15 +77,7 @@ services:
         dbt5-build-egen --include-dir=src/include --patch-dir=patches \
             --source-dir=src /opt/egen
         ln -sf /dev/stderr /tmp/BrokerageHouse_Error.log
-        cp /opt/egen/bin/BrokerageHouseMain /cores/
-        mkdir -p /cores/sysroot/opt/egen/bin
-        cp /opt/egen/bin/BrokerageHouseMain /cores/sysroot/opt/egen/bin/
-        ldd /opt/egen/bin/BrokerageHouseMain | grep -o '/[^ ]*' | \
-            while read -r lib; do \
-                mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
-                cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
-            done || true
-        exec su -s /bin/sh postgres -c "cd /cores && ulimit -c unlimited && \
+        exec su -s /bin/sh postgres -c "ulimit -c unlimited && \
             exec /opt/egen/bin/BrokerageHouseMain -h database \
                              -m market -d dbt5 -o /tmp"
 
@@ -103,13 +95,11 @@ services:
     volumes:
       - .:/usr/local/src/dbt5:ro
       - market-tmp:/tmp/market
-      - ./cores:/cores
     working_dir: /usr/local/src/dbt5
     command:
       - sh
       - -c
       - |
-        mkdir -p /cores && chmod 777 /cores
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build /tmp/build
@@ -118,15 +108,7 @@ services:
             --source-dir=src /opt/egen
         ln -sf /dev/stderr /tmp/error-me-1.log
         ln -sf /dev/stdio /tmp/MarketExchange.log
-        cp /opt/egen/bin/MarketExchangeMain /cores/
-        mkdir -p /cores/sysroot/opt/egen/bin
-        cp /opt/egen/bin/MarketExchangeMain /cores/sysroot/opt/egen/bin/
-        ldd /opt/egen/bin/MarketExchangeMain | grep -o '/[^ ]*' | \
-            while read -r lib; do \
-                mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
-                cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
-            done || true
-        cd /cores && ulimit -c unlimited
+        ulimit -c unlimited
         exec /opt/egen/bin/MarketExchangeMain -h broker -i /opt/egen/flat_in \
             -t ${CUSTOMERS:-1000} -o /tmp/market
 
@@ -142,13 +124,11 @@ services:
       core: -1
     volumes:
       - .:/usr/local/src/dbt5:ro
-      - ./cores:/cores
     working_dir: /tmp
     entrypoint:
       - sh
       - -c
       - |
-        mkdir -p /cores && chmod 777 /cores
         cd /usr/local/src/dbt5
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -164,17 +144,7 @@ services:
           done
           sleep 1
         done) &
-        cp /opt/egen/bin/* /cores/ 2>/dev/null || true
-        mkdir -p /cores/sysroot/opt/egen/bin
-        cp /opt/egen/bin/* /cores/sysroot/opt/egen/bin/ 2>/dev/null || true
-        for b in /opt/egen/bin/*; do \
-            ldd "$$b" 2>/dev/null | grep -o '/[^ ]*' | \
-                while read -r lib; do \
-                    mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
-                    cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
-                done; \
-        done || true
-        cd /cores && ulimit -c unlimited
+        ulimit -c unlimited
         exec dbt5-build --tpcetools=/opt/egen -l CUSTOM --db-host=database \
             --db-user=${USER} -t ${CUSTOMERS:-1000} -w ${DAYS:-1} \
             -f ${SCALEFACTOR:-1} pgsql "$$@"
@@ -194,13 +164,11 @@ services:
       - .:/usr/local/src/dbt5:ro
       - ./results:/tmp/results
       - market-tmp:/tmp/market:ro
-      - ./cores:/cores
     working_dir: /tmp
     entrypoint:
       - sh
       - -c
       - |
-        mkdir -p /cores && chmod 777 /cores
         cd /usr/local/src/dbt5
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo
@@ -218,15 +186,7 @@ services:
           done
           sleep 1
         done) &
-        cp /opt/egen/bin/DriverMain /cores/
-        mkdir -p /cores/sysroot/opt/egen/bin
-        cp /opt/egen/bin/DriverMain /cores/sysroot/opt/egen/bin/
-        ldd /opt/egen/bin/DriverMain | grep -o '/[^ ]*' | \
-            while read -r lib; do \
-                mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
-                cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
-            done || true
-        cd /cores && ulimit -c unlimited
+        ulimit -c unlimited
         /opt/egen/bin/DriverMain -h broker -i /opt/egen/flat_in -o "$$OUTDIR" \
             -t ${CUSTOMERS:-1000} -w ${DAYS:-1} -f ${SCALEFACTOR:-1} \
             -u ${USERS:-1} "$$@"

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
         COPY *-tpc-e-tool.zip /tmp/
         RUN TPCEZIP=$$(ls /tmp/*-tpc-e-tool.zip 2>/dev/null | tail -1) \
             && unzip -q "$$TPCEZIP" -d /opt/egen && rm /tmp/*-tpc-e-tool.zip
+        RUN echo "ulimit -c unlimited" >> /etc/bash.bashrc
       args:
         PGVER: ${PGVER:-18}
     image: dbt5-base:${PGVER:-18}
@@ -53,11 +54,15 @@ services:
       - "30000:30000"
     volumes:
       - .:/usr/local/src/dbt5:ro
+      - ./cores:/cores
     working_dir: /usr/local/src/dbt5
+    ulimits:
+      core: -1
     command:
       - sh
       - -c
       - |
+        ulimit -c unlimited
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
         cmake --build /tmp/build
         cmake --install /tmp/build
@@ -79,11 +84,15 @@ services:
     volumes:
       - .:/usr/local/src/dbt5:ro
       - market-tmp:/tmp/market
+      - ./cores:/cores
     working_dir: /usr/local/src/dbt5
+    ulimits:
+      core: -1
     command:
       - sh
       - -c
       - |
+        ulimit -c unlimited
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
         cmake --build /tmp/build
         cmake --install /tmp/build
@@ -140,11 +149,15 @@ services:
       - .:/usr/local/src/dbt5:ro
       - ./results:/tmp/results
       - market-tmp:/tmp/market:ro
+      - ./cores:/cores
     working_dir: /tmp
+    ulimits:
+      core: -1
     entrypoint:
       - sh
       - -c
       - |
+        ulimit -c unlimited
         cd /usr/local/src/dbt5
         cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
         cmake --build /tmp/build

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,11 @@
 ---
+# Debugging: services build with RelWithDebInfo and write core dumps to ./cores/.
+# Host prerequisite (one-time):
+#   sudo sysctl -w kernel.core_pattern=core.%e.%p
+# Analyse a core inside the matching container (recommended):
+#   docker compose exec broker gdb /opt/egen/bin/BrokerageHouseMain /cores/core.*
+# Analyse a core locally (binaries and libs are auto-copied to ./cores/):
+#   gdb -ex "set sysroot ./cores/sysroot" ./cores/BrokerageHouseMain ./cores/core.*
 services:
   dbt5-base:
     build:
@@ -7,12 +14,12 @@ services:
         ARG PGVER=18
         FROM postgres:$${PGVER}
         RUN apt-get update && apt-get install -y --no-install-recommends \
-            build-essential cmake postgresql-server-dev-$${PG_MAJOR} unzip \
+            build-essential cmake gdb libc6-dbg \
+            postgresql-server-dev-$${PG_MAJOR} unzip \
             && rm -rf /var/lib/apt/lists/*
         COPY *-tpc-e-tool.zip /tmp/
         RUN TPCEZIP=$$(ls /tmp/*-tpc-e-tool.zip 2>/dev/null | tail -1) \
             && unzip -q "$$TPCEZIP" -d /opt/egen && rm /tmp/*-tpc-e-tool.zip
-        RUN echo "ulimit -c unlimited" >> /etc/bash.bashrc
       args:
         PGVER: ${PGVER:-18}
     image: dbt5-base:${PGVER:-18}
@@ -50,26 +57,36 @@ services:
         condition: service_completed_successfully
       database:
         condition: service_started
+    ulimits:
+      core: -1
     ports:
       - "30000:30000"
     volumes:
       - .:/usr/local/src/dbt5:ro
       - ./cores:/cores
     working_dir: /usr/local/src/dbt5
-    ulimits:
-      core: -1
     command:
       - sh
       - -c
       - |
-        ulimit -c unlimited
-        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
+        mkdir -p /cores && chmod 777 /cores
+        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build /tmp/build
         cmake --install /tmp/build
         dbt5-build-egen --include-dir=src/include --patch-dir=patches \
             --source-dir=src /opt/egen
         ln -sf /dev/stderr /tmp/BrokerageHouse_Error.log
-        exec su postgres -c "/opt/egen/bin/BrokerageHouseMain -h database \
+        cp /opt/egen/bin/BrokerageHouseMain /cores/
+        mkdir -p /cores/sysroot/opt/egen/bin
+        cp /opt/egen/bin/BrokerageHouseMain /cores/sysroot/opt/egen/bin/
+        ldd /opt/egen/bin/BrokerageHouseMain | grep -o '/[^ ]*' | \
+            while read -r lib; do \
+                mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
+                cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
+            done || true
+        exec su -s /bin/sh postgres -c "cd /cores && ulimit -c unlimited && \
+            exec /opt/egen/bin/BrokerageHouseMain -h database \
                              -m market -d dbt5 -o /tmp"
 
   market:
@@ -79,6 +96,8 @@ services:
         condition: service_completed_successfully
       broker:
         condition: service_started
+    ulimits:
+      core: -1
     ports:
       - "30010:30010"
     volumes:
@@ -86,20 +105,28 @@ services:
       - market-tmp:/tmp/market
       - ./cores:/cores
     working_dir: /usr/local/src/dbt5
-    ulimits:
-      core: -1
     command:
       - sh
       - -c
       - |
-        ulimit -c unlimited
-        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
+        mkdir -p /cores && chmod 777 /cores
+        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build /tmp/build
         cmake --install /tmp/build
         dbt5-build-egen --include-dir=src/include --patch-dir=patches \
             --source-dir=src /opt/egen
         ln -sf /dev/stderr /tmp/error-me-1.log
         ln -sf /dev/stdio /tmp/MarketExchange.log
+        cp /opt/egen/bin/MarketExchangeMain /cores/
+        mkdir -p /cores/sysroot/opt/egen/bin
+        cp /opt/egen/bin/MarketExchangeMain /cores/sysroot/opt/egen/bin/
+        ldd /opt/egen/bin/MarketExchangeMain | grep -o '/[^ ]*' | \
+            while read -r lib; do \
+                mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
+                cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
+            done || true
+        cd /cores && ulimit -c unlimited
         exec /opt/egen/bin/MarketExchangeMain -h broker -i /opt/egen/flat_in \
             -t ${CUSTOMERS:-1000} -o /tmp/market
 
@@ -111,15 +138,20 @@ services:
         condition: service_completed_successfully
       database:
         condition: service_started
+    ulimits:
+      core: -1
     volumes:
       - .:/usr/local/src/dbt5:ro
+      - ./cores:/cores
     working_dir: /tmp
     entrypoint:
       - sh
       - -c
       - |
+        mkdir -p /cores && chmod 777 /cores
         cd /usr/local/src/dbt5
-        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
+        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build /tmp/build
         cmake --install /tmp/build
         dbt5-build-egen --include-dir=src/include --patch-dir=patches \
@@ -132,6 +164,17 @@ services:
           done
           sleep 1
         done) &
+        cp /opt/egen/bin/* /cores/ 2>/dev/null || true
+        mkdir -p /cores/sysroot/opt/egen/bin
+        cp /opt/egen/bin/* /cores/sysroot/opt/egen/bin/ 2>/dev/null || true
+        for b in /opt/egen/bin/*; do \
+            ldd "$$b" 2>/dev/null | grep -o '/[^ ]*' | \
+                while read -r lib; do \
+                    mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
+                    cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
+                done; \
+        done || true
+        cd /cores && ulimit -c unlimited
         exec dbt5-build --tpcetools=/opt/egen -l CUSTOM --db-host=database \
             --db-user=${USER} -t ${CUSTOMERS:-1000} -w ${DAYS:-1} \
             -f ${SCALEFACTOR:-1} pgsql "$$@"
@@ -145,21 +188,22 @@ services:
         condition: service_completed_successfully
       market:
         condition: service_started
+    ulimits:
+      core: -1
     volumes:
       - .:/usr/local/src/dbt5:ro
       - ./results:/tmp/results
       - market-tmp:/tmp/market:ro
       - ./cores:/cores
     working_dir: /tmp
-    ulimits:
-      core: -1
     entrypoint:
       - sh
       - -c
       - |
-        ulimit -c unlimited
+        mkdir -p /cores && chmod 777 /cores
         cd /usr/local/src/dbt5
-        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr
+        cmake -H. -B/tmp/build -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build /tmp/build
         cmake --install /tmp/build
         dbt5-build-egen --include-dir=src/include --patch-dir=patches \
@@ -174,6 +218,15 @@ services:
           done
           sleep 1
         done) &
+        cp /opt/egen/bin/DriverMain /cores/
+        mkdir -p /cores/sysroot/opt/egen/bin
+        cp /opt/egen/bin/DriverMain /cores/sysroot/opt/egen/bin/
+        ldd /opt/egen/bin/DriverMain | grep -o '/[^ ]*' | \
+            while read -r lib; do \
+                mkdir -p "/cores/sysroot$$(dirname "$$lib")" && \
+                cp -n "$$lib" "/cores/sysroot$$lib" 2>/dev/null; \
+            done || true
+        cd /cores && ulimit -c unlimited
         /opt/egen/bin/DriverMain -h broker -i /opt/egen/flat_in -o "$$OUTDIR" \
             -t ${CUSTOMERS:-1000} -w ${DAYS:-1} -f ${SCALEFACTOR:-1} \
             -u ${USERS:-1} "$$@"


### PR DESCRIPTION
Hey @markwkm, with reference to issue #34, I have implemented a minimal solution for core dump support:

**Changes:**
- Add `ulimits: core: -1` to broker, market, and driver services
- Add `./cores:/cores` volume mount to persist core dumps on host
- Add `ulimit -c unlimited` in startup scripts
- Update `.gitignore` and `.dockerignore` to exclude `cores/`

**If you are using WSL, you'll need to configure the host:**
```bash
sudo sysctl -w kernel.core_pattern="$(pwd)/cores/core.%e.%p.%t"
```
Another option is using `privileged: true`, but i guess that would be less secure.

**Test:**
```bash
docker compose exec broker bash -c 'cat > /tmp/crash.c << "EOF"
#include <stdio.h>
int main() { int *p = NULL; *p = 42; return 0; }
EOF
gcc -g /tmp/crash.c -o /tmp/crash && /tmp/crash'

ls -lh cores/  # Should show core dump file
```

I hope this solves the purpose. Should I add documentation if this approach is acceptable?
