### PR TITLE
refactor: replace 'throw new' with value-based exceptions for CThreadErr

### DIFF
--- a/src/BrokerageHouse/BrokerageHouse.cpp
+++ b/src/BrokerageHouse/BrokerageHouse.cpp
@@ -259,14 +259,14 @@ entryWorkerThread(void *data)
 		// initialize the attribute object
 		int status = pthread_attr_init(&threadAttribute);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
 		}
 
 		// set the detachstate attribute to detached
 		status = pthread_attr_setdetachstate(
 				&threadAttribute, PTHREAD_CREATE_DETACHED);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
 		}
 
 		// create the thread in the detached state
@@ -274,19 +274,18 @@ entryWorkerThread(void *data)
 				&threadID, &threadAttribute, &workerThread, data);
 
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_CREATE);
+			throw CThreadErr(CThreadErr::ERR_THREAD_CREATE);
 		}
-	} catch (CThreadErr *pErr) {
+	} catch (const CThreadErr &pErr) {
 		// close recently accepted connection, to release driver threads
 		close(pThrParam->iSockfd);
 
 		ostringstream osErr;
-		osErr << "Error: " << pErr->ErrorText() << " at "
+		osErr << "Error: " << pErr.ErrorText() << " at "
 			  << "BrokerageHouse::entryWorkerThread" << endl
 			  << "accepted socket connection closed" << endl;
 		pThrParam->pBrokerageHouse->logErrorMessage(osErr.str());
 		delete pThrParam;
-		delete pErr;
 	}
 }
 

--- a/src/Driver/Driver.cpp
+++ b/src/Driver/Driver.cpp
@@ -135,7 +135,7 @@ entryCustomerWorkerThread(void *data)
 		// initialize the attribute object
 		int status = pthread_attr_init(&threadAttribute);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
 		}
 
 		// create the thread in the joinable state
@@ -143,13 +143,13 @@ entryCustomerWorkerThread(void *data)
 				&customerWorkerThread, data);
 
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_CREATE);
+			throw CThreadErr(CThreadErr::ERR_THREAD_CREATE);
 		}
-	} catch (CThreadErr *pErr) {
+	} catch (const CThreadErr &pErr) {
 		cerr << "Thread " << pThrParam->UniqueId << " didn't spawn correctly"
 			 << endl
 			 << endl
-			 << "Error: " << pErr->ErrorText()
+			 << "Error: " << pErr.ErrorText()
 			 << " at EntryCustomerWorkerThread" << endl;
 		exit(1);
 	}
@@ -241,8 +241,7 @@ CDriver::runTest(int iSleep, int iTestDuration)
 	// 0 represents the Data-Maintenance thread
 	for (int i = 0; i <= iUsers; i++) {
 		if (pthread_join(g_tid[i], NULL) != 0) {
-			throw new CThreadErr(
-					CThreadErr::ERR_THREAD_JOIN, "Driver::RunTest");
+			throw CThreadErr(CThreadErr::ERR_THREAD_JOIN, "Driver::RunTest");
 		}
 	}
 }
@@ -295,7 +294,7 @@ entryDMWorkerThread(CDriver *ptr)
 				reinterpret_cast<void *>(pThrParam));
 
 		cout << ">> Data-Maintenance thread started." << endl;
-	} catch (CThreadErr *pErr) {
+	} catch (const CThreadErr &pErr) {
 		cerr << "Data-Maintenance thread not created successfully, exiting..."
 			 << endl;
 		exit(1);

--- a/src/MarketExchange/MarketExchange.cpp
+++ b/src/MarketExchange/MarketExchange.cpp
@@ -74,14 +74,14 @@ EntryMarketWorkerThread(void *data)
 		// initialize the attribute object
 		int status = pthread_attr_init(&threadAttribute);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
 		}
 
 		// set the detachstate attribute to detached
 		status = pthread_attr_setdetachstate(
 				&threadAttribute, PTHREAD_CREATE_DETACHED);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
 		}
 
 		// create the thread in the detached state
@@ -89,16 +89,15 @@ EntryMarketWorkerThread(void *data)
 				&threadID, &threadAttribute, &MarketWorkerThread, data);
 
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_CREATE);
+			throw CThreadErr(CThreadErr::ERR_THREAD_CREATE);
 		}
-	} catch (CThreadErr *pErr) {
+	} catch (const CThreadErr &pErr) {
 		// close recently accepted connection, to release threads
 		close(pThrParam->iSockfd);
 
-		cerr << "Error: " << pErr->ErrorText()
+		cerr << "Error: " << pErr.ErrorText()
 			 << " at MarketExchange::entryMarketWorkerThread" << endl
 			 << "accepted socket connection closed" << endl;
-		delete pErr;
 	}
 }
 

--- a/src/interfaces/MEESUT.cpp
+++ b/src/interfaces/MEESUT.cpp
@@ -43,14 +43,14 @@ RunTradeResultAsync(void *data)
 		// initialize the attribute object
 		int status = pthread_attr_init(&threadAttribute);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
 		}
 
 		// set the detachstate attribute to detached
 		status = pthread_attr_setdetachstate(
 				&threadAttribute, PTHREAD_CREATE_DETACHED);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
 		}
 
 		// create the thread in the detached state - Call Trade Result
@@ -59,14 +59,13 @@ RunTradeResultAsync(void *data)
 				&threadID, &threadAttribute, &TradeResultAsync, data);
 
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_CREATE);
+			throw CThreadErr(CThreadErr::ERR_THREAD_CREATE);
 		}
-	} catch (CThreadErr *pErr) {
+	} catch (const CThreadErr &pErr) {
 		ostringstream osErr;
-		osErr << "Error: " << pErr->ErrorText()
+		osErr << "Error: " << pErr.ErrorText()
 			  << " at MEESUT::RunTradeResultAsync" << endl;
 		pThrParam->pCMEESUT->logErrorMessage(osErr.str());
-		delete pErr;
 		return false;
 	}
 
@@ -123,14 +122,14 @@ RunMarketFeedAsync(void *data)
 		// initialize the attribute object
 		int status = pthread_attr_init(&threadAttribute);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_INIT);
 		}
 
 		// set the detachstate attribute to detached
 		status = pthread_attr_setdetachstate(
 				&threadAttribute, PTHREAD_CREATE_DETACHED);
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
+			throw CThreadErr(CThreadErr::ERR_THREAD_ATTR_DETACH);
 		}
 
 		// create the thread in the detached state - Call Trade Result
@@ -139,14 +138,13 @@ RunMarketFeedAsync(void *data)
 				&threadID, &threadAttribute, &MarketFeedAsync, data);
 
 		if (status != 0) {
-			throw new CThreadErr(CThreadErr::ERR_THREAD_CREATE);
+			throw CThreadErr(CThreadErr::ERR_THREAD_CREATE);
 		}
-	} catch (CThreadErr *pErr) {
+	} catch (const CThreadErr &pErr) {
 		ostringstream osErr;
-		osErr << "Error: " << pErr->ErrorText()
+		osErr << "Error: " << pErr.ErrorText()
 			  << " at MEESUT::RunMarketFeedAsync" << endl;
 		pThrParam->pCMEESUT->logErrorMessage(osErr.str());
-		delete pErr;
 		return false;
 	}
 


### PR DESCRIPTION
The codebase uses `throw new CThreadErr(...)` which allocates the
exception object on the heap. This requires catch blocks to manually
`delete` the pointer to avoid memory leaks. Several catch blocks were
missing this `delete`.

Replace with value-based throws and catch by `const CThreadErr&`,
letting the compiler manage the exception object lifetime automatically.

Changes:
- src/Driver/Driver.cpp
- src/interfaces/MEESUT.cpp
- src/MarketExchange/MarketExchange.cpp
- src/BrokerageHouse/BrokerageHouse.cpp
