### PR TITLE
Add touchstone-tools link to dbt5 docs

### DIFF
--- a/doc/dbt5.rst
+++ b/doc/dbt5.rst
@@ -69,7 +69,7 @@ required:
 
 Optional software:
 
-* **ts** https://gitlab.com/touchstone/touchstone-byo1/ for profiling
+* **ts** https://gitlab.com/touchstone/touchstone-tools/ for profiling
 * **sar**, **pidstat** http://pagesperso-orange.fr/sebastien.godard/ (While the
   scripts assume this particular version of **sar** and **pidstat**, it is
   possible to run on non-Linux based operating systems with some modifications

--- a/doc/dbt5.rst
+++ b/doc/dbt5.rst
@@ -69,6 +69,7 @@ required:
 
 Optional software:
 
+* **ts** https://gitlab.com/touchstone/touchstone-byo1/ for profiling
 * **sar**, **pidstat** http://pagesperso-orange.fr/sebastien.godard/ (While the
   scripts assume this particular version of **sar** and **pidstat**, it is
   possible to run on non-Linux based operating systems with some modifications


### PR DESCRIPTION
In response to [this issue](https://github.com/osdldbt/dbt5/issues/38).